### PR TITLE
Refactor of sessions and skatepark index js logic for readability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,86 +1,51 @@
 source 'https://rubygems.org'
-
 ruby '2.2.3'
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.5.1'
-# Use postgresql as the database for Active Record
-gem 'pg'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
-# Use ActiveModel has_secure_password
-gem 'bcrypt', '~> 3.1.7'
 
 gem 'administrate', '~> 0.1.3'
-gem 'sprockets-rails'
-gem 'puma'
-gem 'turbolinks'
-gem 'geokit'
-gem 'therubyracer'
-gem 'underscore-rails'
-gem 'less-rails', '~> 2.7.1'
-gem 'gmaps4rails'
-gem 'less-rails-semantic_ui', '~> 2.1.8.1'
 gem 'autoprefixer-rails', '~> 6.0'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
-
+gem 'bcrypt', '~> 3.1.7'
+gem 'geokit'
+gem 'gmaps4rails'
+gem 'jquery-rails'
+gem 'less-rails', '~> 2.7.1'
+gem 'less-rails-semantic_ui', '~> 2.1.8.1'
+gem 'pg'
+gem 'puma'
 gem 'rails_12factor', group: :production
-
-group :development do
-  gem 'web-console', '~> 3.1.1'
-end
+gem 'sass-rails', '~> 5.0'
+gem 'sprockets-rails'
+gem 'therubyracer'
+gem 'turbolinks'
+gem 'uglifier', '>= 1.3.0'
+gem 'underscore-rails'
 
 group :assets do
   gem 'coffee-rails'
 end
 
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'pry-rails'
-  gem 'pry-byebug'
-  gem 'rspec-rails'
-  gem 'capybara'
-  gem 'capybara-webkit'
-  gem 'factory_girl_rails'
-  gem 'teaspoon-mocha'
-  gem 'magic_lamp'
-  gem 'bundler-audit', require: false
-  gem 'dotenv-rails'
-end
-
-group :test do
-  gem 'database_cleaner'
-  gem 'rake'
+group :development do
+  gem 'web-console', '~> 3.1.1'
 end
 
 group :development, :production do
   gem 'forgery', '0.6.0'
 end
 
-#bullshit gems - delete at some point!
+group :development, :test do
+  gem 'bundler-audit', require: false
+  gem 'capybara'
+  gem 'capybara-webkit'
+  gem 'dotenv-rails'
+  gem 'factory_girl_rails'
+  gem 'magic_lamp'
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'rspec-rails'
+  gem 'teaspoon-mocha'
+end
 
-
-# Use CoffeeScript for .js.coffee assets and views
-# gem 'coffee-rails', '~> 4.0.0'
-
-
-
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer',  platforms: :ruby
-
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
-# gem 'sdoc', '~> 0.4.0',          group: :doc
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Use debugger
-# gem 'debugger', group: [:development, :test]
-
+group :test do
+  gem 'database_cleaner'
+  gem 'rake'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'rails', '4.2.5.1'
 
 gem 'administrate', '~> 0.1.3'
 gem 'autoprefixer-rails', '~> 6.0'
+gem 'awesome_print'
 gem 'bcrypt', '~> 3.1.7'
 gem 'geokit'
 gem 'gmaps4rails'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :assets do
 end
 
 group :development do
+  gem 'quiet_assets'
   gem 'web-console', '~> 3.1.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (2.16.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -271,6 +273,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
+  quiet_assets
   rails (= 4.2.5.1)
   rails_12factor
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     autoprefixer-rails (6.3.1)
       execjs
       json
+    awesome_print (1.6.1)
     bcrypt (3.1.10)
     bourbon (4.2.6)
       sass (~> 3.4)
@@ -250,6 +251,7 @@ PLATFORMS
 DEPENDENCIES
   administrate (~> 0.1.3)
   autoprefixer-rails (~> 6.0)
+  awesome_print
   bcrypt (~> 3.1.7)
   bundler-audit
   capybara

--- a/app/assets/javascripts/favorite-button.js
+++ b/app/assets/javascripts/favorite-button.js
@@ -1,12 +1,20 @@
 $(document).ready(function() {
+  var showRemoveFavoriteBtn = function () {
+    $('.remove-favorite-button').removeClass('hidden');
+    $('.add-favorite-button').addClass('hidden');
+  };
+  var showAddFavoriteBtn = function () {
+    $('.add-favorite-button').removeClass('hidden');
+    $('.remove-favorite-button').addClass('hidden');
+  };
+
 
   $('.add-favorite-button').on('submit', function(event){
-    AJAX['favorite']['post'](event);
+    AJAX(event, 'post', showRemoveFavoriteBtn);
   });
 
   $('.remove-favorite-button').on('submit', function(event){
-    AJAX['favorite']['put'](event);
+    AJAX(event, 'put', showAddFavoriteBtn);
   });
-
 });
 

--- a/app/assets/javascripts/favorite-button.js
+++ b/app/assets/javascripts/favorite-button.js
@@ -1,20 +1,20 @@
 $(document).ready(function() {
-  var showRemoveFavoriteBtn = function () {
-    $('.remove-favorite-button').removeClass('hidden');
-    $('.add-favorite-button').addClass('hidden');
-  };
-  var showAddFavoriteBtn = function () {
-    $('.add-favorite-button').removeClass('hidden');
-    $('.remove-favorite-button').addClass('hidden');
-  };
-
-
   $('.add-favorite-button').on('submit', function(event){
-    AJAX(event, 'post', showRemoveFavoriteBtn);
+    AJAX(event, 'post', function () {
+      toggleVisibility({
+        show: $('.remove-favorite-button'),
+        hide: $('.add-favorite-button')
+      });
+    });
   });
 
   $('.remove-favorite-button').on('submit', function(event){
-    AJAX(event, 'put', showAddFavoriteBtn);
+    AJAX(event, 'put', function () {
+      toggleVisibility({
+        show: $('.add-favorite-button'),
+        hide: $('.remove-favorite-button')
+      });
+    });
   });
 });
 

--- a/app/assets/javascripts/favorite-button.js
+++ b/app/assets/javascripts/favorite-button.js
@@ -1,20 +1,16 @@
 $(document).ready(function() {
   $('.add-favorite-button').on('submit', function(event){
-    AJAX(event, 'post', function () {
-      toggleVisibility({
-        show: $('.remove-favorite-button'),
-        hide: $('.add-favorite-button')
-      });
-    });
+    favoriteRequest('post', $(event.target), $('.remove-favorite-button'));
   });
 
   $('.remove-favorite-button').on('submit', function(event){
-    AJAX(event, 'put', function () {
-      toggleVisibility({
-        show: $('.add-favorite-button'),
-        hide: $('.remove-favorite-button')
-      });
-    });
+    favoriteRequest('put', $(event.target), $('.add-favorite-button'));
   });
+
+  function favoriteRequest(method, hide, show) {
+    AJAX(event, method, function () {
+      toggleVisibility({ hide: hide, show: show });
+    });
+  }
 });
 

--- a/app/assets/javascripts/modules/ajax-module.js
+++ b/app/assets/javascripts/modules/ajax-module.js
@@ -15,66 +15,7 @@ var AJAX = (function(){
     }
   };
 
-  var callbacks = {
-    visit: {
-      post: function() {
-        $('.remove-visit-button').removeClass('hidden');
-        $('.add-visit-button').addClass('hidden');
-        $('.opinions-container').removeClass('hidden');
-      },
-      put: function() {
-        $('.remove-visit-button').addClass('hidden');
-        $('.add-visit-button').removeClass('hidden');
-        $('.opinions-container').addClass('hidden');
-      }
-    },
-    favorite: {
-      post: function() {
-        $('.remove-favorite-button').removeClass('hidden');
-        $('.add-favorite-button').addClass('hidden');
-      },
-      put: function() {
-        $('.remove-favorite-button').addClass('hidden');
-        $('.add-favorite-button').removeClass('hidden');
-      }
-    },
-    search: function(response) {
-      $(".search-results-container").remove();
-      $(".search-container").append(response);
-    },
-    state: function(response, event) {
-      $(event.target).addClass('active').siblings().removeClass('active');
-      $(".parks-container").children().remove();
-      $(".parks-container").append(response);
-    }
-  };
-
-  var exports = {
-    visit: {
-      post: function(event) {
-        ajaxRequest(event, 'post', callbacks['visit']['post']);
-      },
-      put: function(event) {
-        ajaxRequest(event, 'put', callbacks['visit']['put']);
-      }
-    },
-    favorite: {
-      post: function(event) {
-        ajaxRequest(event, 'post', callbacks['favorite']['post']);
-      },
-      put: function(event) {
-        ajaxRequest(event, 'put', callbacks['favorite']['put']);
-      }
-    },
-    search: function(event) {
-      ajaxRequest(event, 'get', callbacks['search']);
-    },
-    state: function(event) {
-      ajaxRequest(event, 'get', callbacks['state']);
-    }
-  };
-
-  function ajaxRequest(event, method, callback) {
+  var ajaxRequest = function (event, method, callback) {
     event.preventDefault();
     var request;
     var comingFromAform = $(event.target).attr('action');
@@ -93,7 +34,7 @@ var AJAX = (function(){
     });
   }
 
-  return exports;
+  return ajaxRequest;
 
 }());
 

--- a/app/assets/javascripts/modules/ajax-module.js
+++ b/app/assets/javascripts/modules/ajax-module.js
@@ -25,8 +25,14 @@ var AJAX = (function(){
     search: function(response) {
       $(".search-results-container").remove();
       $(".search-container").append(response);
+    },
+    state: function(response, event) {
+      slideUpImages();
+      $(event.target).addClass('active').siblings().removeClass('active');
+      $(".parks-container").children().remove();
+      $(".parks-container").append(response);
     }
-  }
+  };
 
   function ajaxRequest(event, method, callback) {
     event.preventDefault();
@@ -36,7 +42,7 @@ var AJAX = (function(){
       method: method
     })
     .done(function(response) {
-      callback(response);
+      callback(response, event);
     })
     .fail(function(response){
       console.log(response);
@@ -61,9 +67,12 @@ var AJAX = (function(){
       }
     },
     search: function(event) {
-      ajaxRequest(event, 'get', callbacks['search'])
+      ajaxRequest(event, 'get', callbacks['search']);
+    },
+    state: function(event) {
+      ajaxRequest(event, 'get', callbacks['state']);
     }
-  }
+  };
 
   return exports;
 

--- a/app/assets/javascripts/modules/ajax-module.js
+++ b/app/assets/javascripts/modules/ajax-module.js
@@ -1,4 +1,20 @@
 var AJAX = (function(){
+  var requests = {
+    form: function(event, method) {
+      return $.ajax({
+        url: $(event.target).attr('action'),
+        data: $(event.target).serialize(),
+        method: method
+      });
+    },
+
+    link: function(event) {
+      return $.ajax({
+        url: $(event.target).attr('href')
+      });
+    }
+  };
+
   var callbacks = {
     visit: {
       post: function() {
@@ -27,27 +43,11 @@ var AJAX = (function(){
       $(".search-container").append(response);
     },
     state: function(response, event) {
-      slideUpImages();
       $(event.target).addClass('active').siblings().removeClass('active');
       $(".parks-container").children().remove();
       $(".parks-container").append(response);
     }
   };
-
-  function ajaxRequest(event, method, callback) {
-    event.preventDefault();
-    $.ajax({
-      url: $(event.target).attr('action'),
-      data: $(event.target).serialize(),
-      method: method
-    })
-    .done(function(response) {
-      callback(response, event);
-    })
-    .fail(function(response){
-      console.log(response);
-    });
-  }
 
   var exports = {
     visit: {
@@ -73,6 +73,25 @@ var AJAX = (function(){
       ajaxRequest(event, 'get', callbacks['state']);
     }
   };
+
+  function ajaxRequest(event, method, callback) {
+    event.preventDefault();
+    var request;
+    var comingFromAform = $(event.target).attr('action');
+
+    if (comingFromAform) {
+      request = requests.form(event, method);
+    } else {
+      request = requests.link(event);
+    }
+
+    request.done(function(response) {
+      callback(response, event);
+    });
+    request.fail(function(response){
+      console.log(response, event);
+    });
+  }
 
   return exports;
 

--- a/app/assets/javascripts/modules/image-rotator.js
+++ b/app/assets/javascripts/modules/image-rotator.js
@@ -1,9 +1,6 @@
-//$(document).ready(function () {
-  //// image rotation ////
 function ImageRotator() {
   var $container = $('.image-rotator');
   var currentUrl = 0;
-  //var rotationTimer = setInterval(cycleImages, 4000);
   var imageUrls = shuffle([
     'lance-mountain',
     'hewitt',
@@ -57,4 +54,3 @@ function ImageRotator() {
     return array;
   }
 }
-//});

--- a/app/assets/javascripts/modules/image-rotator.js
+++ b/app/assets/javascripts/modules/image-rotator.js
@@ -1,0 +1,60 @@
+//$(document).ready(function () {
+  //// image rotation ////
+function ImageRotator() {
+  var $container = $('.image-rotator');
+  var currentUrl = 0;
+  //var rotationTimer = setInterval(cycleImages, 4000);
+  var imageUrls = shuffle([
+    'lance-mountain',
+    'hewitt',
+    'willis',
+    'beckett',
+    'kowalski',
+    'drehobl',
+    'robbie',
+    'ronnie',
+    'flower-shop'
+  ]);
+
+
+  function animate(url) {
+    $container.fadeOut(1500, function() {
+      $container.css('background-image', googleBucketUrlFrom(url));
+      $container.fadeIn(1500);
+    });
+  }
+
+  this.cycleImages = function () {
+    currentUrl++;
+    if (currentUrl === imageUrls.length - 1) {
+      currentUrl = 0;
+    }
+    animate(imageUrls[currentUrl]);
+  };
+
+  function googleBucketUrlFrom(url) {
+    return "url('https://storage.googleapis.com/west-coast-skateparks/headers/"+url+".jpg')";
+  }
+
+  // shuffles the array of image urls, so it doesn't always go in the same order
+  // stole this off stack overflow
+  function shuffle(array) {
+    var currentIndex = array.length, temporaryValue, randomIndex;
+
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+
+      // Pick a remaining element...
+      randomIndex = Math.floor(Math.random() * currentIndex);
+      currentIndex -= 1;
+
+      // And swap it with the current element.
+      temporaryValue = array[currentIndex];
+      array[currentIndex] = array[randomIndex];
+      array[randomIndex] = temporaryValue;
+    }
+
+    return array;
+  }
+}
+//});

--- a/app/assets/javascripts/modules/marker-generator.js
+++ b/app/assets/javascripts/modules/marker-generator.js
@@ -10,13 +10,13 @@ function MarkerGenerator(map, skateparks) {
         if (type !== 'main') {
           skatepark = JSON.parse(skatepark);
         }
-        var marker = createMarker(skatepark, type)
-        var infowindow = marker['infowindow']
+        var marker = createMarker(skatepark, type);
+        var infowindow = marker.infowindow;
         toggleable[type].push(marker);
       });
       bindVisibilityListener(type);
     });
-  }
+  };
 
   function createMarker(skatepark, type){
     var latLng = { lat: skatepark.latitude, lng: skatepark.longitude };
@@ -45,18 +45,16 @@ function MarkerGenerator(map, skateparks) {
   function bindVisibilityListener(type) {
     $('#toggle-' + type).on('click', function (event) {
       var $button = $(event.target);
-      var action = $button.text().split(' ')
+      var action = $button.text().split(' ');
 
-      if (action[0] === 'Hide') {
-        action[0] = 'Show'
-        $button.text(action.join(' '));
-        toggleMarkerVisibility(toggleable[type], false);
-      } else {
-        action[0] = 'Hide'
-        $button.text(action.join(' '));
-        toggleMarkerVisibility(toggleable[type], true);
-      }
+      toggleMarkerVisibility(toggleable[type], action[0]);
+      toggleButtonText($button, action);
     });
+  }
+
+  function toggleButtonText(button, action) {
+    action[0] = (action[0] === 'Hide') ? 'Show' : 'Hide';
+    button.text(action.join(' '));
   }
 
   function bindInfowindowListener(map, allMarkers, marker, infowindow) {
@@ -69,6 +67,7 @@ function MarkerGenerator(map, skateparks) {
   }
 
   function toggleMarkerVisibility(markers, visibility) {
+    visibility = (visibility === 'Hide') ? false : true;
     markers.forEach(function (marker) {
       if (marker.main) {
         return;
@@ -84,7 +83,7 @@ function MarkerGenerator(map, skateparks) {
 
   function titleize(string) {
     return string.split(' ').map(function(word){
-      return word.charAt(0).toUpperCase() + word.slice(1)
+      return word.charAt(0).toUpperCase() + word.slice(1);
     }).join(' ');
   }
 }

--- a/app/assets/javascripts/modules/marker-generator.js
+++ b/app/assets/javascripts/modules/marker-generator.js
@@ -87,6 +87,4 @@ function MarkerGenerator(map, skateparks) {
       return word.charAt(0).toUpperCase() + word.slice(1)
     }).join(' ');
   }
-
-
 }

--- a/app/assets/javascripts/modules/misc-functions.js
+++ b/app/assets/javascripts/modules/misc-functions.js
@@ -2,3 +2,8 @@ function makeItemClickable(target) {
   window.location = $(target).find("a").attr("href");
   return false;
 }
+
+function toggleVisibility(legend) {
+  legend.hide.addClass('hidden');
+  legend.show.removeClass('hidden');
+}

--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,22 +1,24 @@
 $(document).ready(function(){
+  var appendSearchResultsToContainer = function (response) {
+    $(".search-results-container").remove();
+    $(".search-container").append(response);
+  };
 
   //////// Search form submit via enter key ////////
   $('.search-form').on('submit', function(event) {
-    AJAX['search'](event);
+    AJAX(event, 'get', appendSearchResultsToContainer);
   });
 
   //////// Search form submit via icon click ////////
   $('.circular.search').on('click', function(event) {
+    event.preventDefault();
     var url = $(this).closest('form').attr('action');
     var data = $(this).closest('form').serialize();
     if ($('#search').val() === '') {
       return
     }
     $.ajax({url: url, data: data})
-    .done(function(response) {
-      $(".search-results-container").remove();
-      $(".search-container").append(response);
-    })
+    .done(appendSearchResultsToContainer)
     .fail(function(response){
       console.error(response);
     })

--- a/app/assets/javascripts/skatepark-index.js
+++ b/app/assets/javascripts/skatepark-index.js
@@ -3,23 +3,14 @@ $(document).ready(function(){
 
   //////// Show skateparks by state ////////
   $(".park-state").on('click', function(event){
-    var $stateButton = $(this);
-    event.preventDefault();
+    var $stateButton = $(event.target);
     if ($stateButton.hasClass('active')) {
+      event.preventDefault();
       $stateButton.removeClass('active');
-      return slideDownImages();
+      slideDownImages();
+    } else {
+      AJAX.state(event);
     }
-    slideUpImages();
-    var url = $stateButton.attr('href');
-    $stateButton.addClass('active').siblings().removeClass('active');
-    $.ajax({url: url})
-    .done(function(response) {
-      $(".parks-container").children().remove();
-      $(".parks-container").append(response);
-    })
-    .fail(function(response){
-      console.error(response);
-    })
   });
 
   //////// Select Skatepark From State List ////////

--- a/app/assets/javascripts/skatepark-index.js
+++ b/app/assets/javascripts/skatepark-index.js
@@ -1,6 +1,11 @@
 $(document).ready(function(){
   var rotator = new ImageRotator();
   var rotationTimer = setInterval(rotator.cycleImages, 4000);
+  var appendSkateparksToState = function (response, event) {
+    $(event.target).addClass('active').siblings().removeClass('active');
+    $(".parks-container").children().remove();
+    $(".parks-container").append(response);
+  };
 
   //////// Show skateparks by state ////////
   $(".park-state").on('click', function(event){
@@ -11,7 +16,7 @@ $(document).ready(function(){
       $stateButton.removeClass('active');
       slideDownImages();
     } else {
-      AJAX.state(event);
+      AJAX(event, 'get', appendSkateparksToState);
       slideUpImages();
     }
   });

--- a/app/assets/javascripts/skatepark-index.js
+++ b/app/assets/javascripts/skatepark-index.js
@@ -1,15 +1,18 @@
 $(document).ready(function(){
-
+  var rotator = new ImageRotator();
+  var rotationTimer = setInterval(rotator.cycleImages, 4000);
 
   //////// Show skateparks by state ////////
   $(".park-state").on('click', function(event){
     var $stateButton = $(event.target);
+
     if ($stateButton.hasClass('active')) {
       event.preventDefault();
       $stateButton.removeClass('active');
       slideDownImages();
     } else {
       AJAX.state(event);
+      slideUpImages();
     }
   });
 
@@ -17,28 +20,6 @@ $(document).ready(function(){
   $(".parks-container").on('click', '.item', function(){
     makeItemClickable(this);
   });
-
-  //// image rotation ////
-  var $container = $('.image-rotator');
-  var imageUrls = ['lance-mountain', 'hewitt', 'willis', 'beckett', 'kowalski', 'drehobl', 'robbie', 'ronnie', 'flower-shop'];
-  var currentUrl = 0;
-
-  function animate(string) {
-    $container.fadeOut(1500, function() {
-      $container.css('background-image',"url('https://storage.googleapis.com/west-coast-skateparks/headers/"+string+".jpg')");
-      $container.fadeIn(1500);
-    });
-  }
-
-  function cycleImages() {
-    currentUrl++;
-    if (currentUrl === imageUrls.length - 1) {
-      currentUrl = 0;
-    }
-    animate(imageUrls[currentUrl]);
-  }
-
-  var rotationTimer = setInterval(cycleImages, 4000);
 
   function slideUpImages(){
     clearInterval(rotationTimer);
@@ -48,11 +29,10 @@ $(document).ready(function(){
   }
 
   function slideDownImages() {
-    rotationTimer = setInterval(cycleImages, 4000);
+    rotationTimer = setInterval(rotator.cycleImages, 4000);
     $('.image-rotator').slideDown('slow', function(){
       $('.parks-container').children().remove();
     });
   }
-
 });
 

--- a/app/assets/javascripts/visit-button.js
+++ b/app/assets/javascripts/visit-button.js
@@ -1,12 +1,22 @@
 $(document).ready(function() {
+  var showRemoveVisitBtnShowOpinionsContainer = function () {
+    $('.remove-visit-button').removeClass('hidden');
+    $('.add-visit-button').addClass('hidden');
+    $('.opinions-container').removeClass('hidden');
+  };
+  var showAddVisitBtnHideOpinionsContainer = function () {
+    $('.remove-visit-button').addClass('hidden');
+    $('.add-visit-button').removeClass('hidden');
+    $('.opinions-container').addClass('hidden');
+  };
+
 
   $('.add-visit-button').on('submit', function(event){
-    AJAX['visit']['post'](event);
+    AJAX(event, 'post', showRemoveVisitBtnShowOpinionsContainer);
   });
 
   $('.remove-visit-button').on('submit', function(event){
-    AJAX['visit']['put'](event);
+    AJAX(event, 'put', showAddVisitBtnHideOpinionsContainer);
   });
-
 });
 

--- a/app/assets/javascripts/visit-button.js
+++ b/app/assets/javascripts/visit-button.js
@@ -1,22 +1,32 @@
 $(document).ready(function() {
-  var showRemoveVisitBtnShowOpinionsContainer = function () {
-    $('.remove-visit-button').removeClass('hidden');
-    $('.add-visit-button').addClass('hidden');
-    $('.opinions-container').removeClass('hidden');
-  };
-  var showAddVisitBtnHideOpinionsContainer = function () {
-    $('.remove-visit-button').addClass('hidden');
-    $('.add-visit-button').removeClass('hidden');
-    $('.opinions-container').addClass('hidden');
-  };
-
-
   $('.add-visit-button').on('submit', function(event){
-    AJAX(event, 'post', showRemoveVisitBtnShowOpinionsContainer);
+    AJAX(event, 'post', function () {
+      toggleVisibility({
+        show: $('.remove-visit-button'),
+        hide: $('.add-visit-button')
+      });
+      toggleOpinionsDisplay();
+    });
   });
 
   $('.remove-visit-button').on('submit', function(event){
-    AJAX(event, 'put', showAddVisitBtnHideOpinionsContainer);
+    AJAX(event, 'put', function () {
+      toggleVisibility({
+        hide: $('.remove-visit-button'),
+        show: $('.add-visit-button')
+      });
+      toggleOpinionsDisplay();
+    });
   });
+
+  function toggleOpinionsDisplay() {
+    var $opinions = $('.opinions-container');
+
+    if ($opinions.hasClass('hidden')) {
+      $opinions.addClass('hidden');
+    } else {
+      $opinions.removeClass('hidden');
+    }
+  }
 });
 

--- a/app/assets/javascripts/visit-button.js
+++ b/app/assets/javascripts/visit-button.js
@@ -1,31 +1,26 @@
 $(document).ready(function() {
   $('.add-visit-button').on('submit', function(event){
-    AJAX(event, 'post', function () {
-      toggleVisibility({
-        show: $('.remove-visit-button'),
-        hide: $('.add-visit-button')
-      });
-      toggleOpinionsDisplay();
-    });
+    visitRequest('post', $(event.target), $('.remove-visit-button'));
   });
 
   $('.remove-visit-button').on('submit', function(event){
-    AJAX(event, 'put', function () {
-      toggleVisibility({
-        hide: $('.remove-visit-button'),
-        show: $('.add-visit-button')
-      });
+    visitRequest('put', $(event.target), $('.add-visit-button'));
+  });
+
+  function visitRequest(method, hide, show) {
+    AJAX(event, method, function () {
+      toggleVisibility({ hide: hide, show: show });
       toggleOpinionsDisplay();
     });
-  });
+  }
 
   function toggleOpinionsDisplay() {
     var $opinions = $('.opinions-container');
 
     if ($opinions.hasClass('hidden')) {
-      $opinions.addClass('hidden');
-    } else {
       $opinions.removeClass('hidden');
+    } else {
+      $opinions.addClass('hidden');
     }
   }
 });

--- a/app/controllers/concerns/session_concern.rb
+++ b/app/controllers/concerns/session_concern.rb
@@ -1,5 +1,4 @@
 module SessionConcern
-
   extend ActiveSupport::Concern
 
   included do
@@ -7,30 +6,11 @@ module SessionConcern
     helper_method :logged_in?
   end
 
-  def login
-    if user_authenticated?
-      session[:id] = @user.id
-      redirect_to @user.is_admin? ? admin_root_path : @user
-    else
-      redirect_to new_session_path
-    end
-  end
-
-  def logout
-    session.clear
-  end
-
   def current_user
     @current_user ||= User.where(id: session[:id]).first
   end
 
   def logged_in?
-    !!current_user
+    current_user
   end
-
-  def user_authenticated?
-    @user = User.where(username: params[:username]).first
-    @user && @user.authenticate(params[:password])
-  end
-
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,5 @@
 class SessionsController < ApplicationController
-
   def new
-
   end
 
   def create
@@ -9,7 +7,26 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    logout
-    redirect_to root_path
+    logout && redirect_to(root_path)
+  end
+
+  private
+
+  def login
+    if user_authenticated?
+      session[:id] = @user.id
+      redirect_to @user.is_admin? ? admin_root_path : @user
+    else
+      redirect_to new_session_path
+    end
+  end
+
+  def logout
+    session.clear
+  end
+
+  def user_authenticated?
+    @user ||= User.where(username: params[:username]).first
+    @user && @user.authenticate(params[:password])
   end
 end

--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -20,5 +20,4 @@ class SkateparksController < ApplicationController
     params.require(:skatepark).permit(:name, :city, :state, :rating, :designer, :builder, :opened, :address, :hours, :size, :notes, :helmet)
   end
 
-
 end

--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -19,5 +19,4 @@ class SkateparksController < ApplicationController
   def skatepark_params
     params.require(:skatepark).permit(:name, :city, :state, :rating, :designer, :builder, :opened, :address, :hours, :size, :notes, :helmet)
   end
-
 end

--- a/app/views/skateparks/index.html.erb
+++ b/app/views/skateparks/index.html.erb
@@ -6,9 +6,9 @@
 
     <div class="thirteen wide column">
       <div class='ui centered three item inverted menu state-menu'>
-        <%= link_to 'California', state_path("california"), class: "park-state item", remote: true%>
-        <%= link_to 'Oregon', state_path("oregon"), class: "park-state item", remote: true%>
-        <%= link_to 'Washington', state_path("washington"), class: "park-state ui item", remote: true%>
+        <%= link_to 'California', state_path(state: "california"), class: "park-state item" %>
+        <%= link_to 'Oregon', state_path(state: "oregon"), class: "park-state item" %>
+        <%= link_to 'Washington', state_path(state: "washington"), class: "park-state ui item" %>
       </div>
       <div class="parks-container"></div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   namespace :admin do
     DashboardManifest::DASHBOARDS.each do |dashboard_resource|
       resources dashboard_resource
@@ -8,18 +7,13 @@ Rails.application.routes.draw do
     root controller: DashboardManifest::ROOT_DASHBOARD, action: :index
   end
 
-  #for JS tests
-  mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp)
+  mount MagicLamp::Genie, at: '/magic_lamp' if defined?(MagicLamp)
 
-  get 'about',  to: 'welcome#about', as: 'about'
-  get '/skateparks/search', to: 'skateparks#search', as: 'search'
   resources :users, only: [:show, :new, :create]
   resources :sessions, only: [:new, :create, :destroy]
   resources :skateparks
-  get '/states/:state/skateparks', to: 'skateparks#state', as: 'state'
 
-  put '/users/:user_id/skateparks/:id/add_favorite', to: 'skateparks#add_favorite', as: 'add_favorite'
-  put '/users/:user_id/skateparks/:id/remove_favorite', to: 'skateparks#remove_favorite', as: 'remove_favorite'
+  get '/search', to: 'skateparks#search', as: 'search'
 
   post '/visits', to: 'visits#create'
   put '/visits', to: 'visits#update'
@@ -30,56 +24,6 @@ Rails.application.routes.draw do
   put '/rate', to: 'opinions#rate'
   put '/review', to: 'opinions#review'
 
+  get 'about', to: 'welcome#about', as: 'about'
   root 'welcome#index'
-
-
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :sessions, only: [:new, :create, :destroy]
   resources :skateparks
 
+  get '/state', to: 'skateparks#state', as: 'state'
   get '/search', to: 'skateparks#search', as: 'search'
 
   post '/visits', to: 'visits#create'

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -1,9 +1,8 @@
-require 'rails_helper'
 
 RSpec.feature 'User signs in' do
-  scenario 'tries to access admin dashboard and is redirected with error message' do
-    user = create(:user)
+  let(:user) { create(:user) }
 
+  scenario 'tries to access admin dashboard and is redirected with error message' do
     visit new_session_path
     fill_in 'Username', with: user.username
     fill_in 'Password', with: user.password
@@ -13,5 +12,18 @@ RSpec.feature 'User signs in' do
 
     expect(current_path).to eq(new_session_path)
     expect(page).to have_text('You need admin authentication to access that.')
+  end
+
+  scenario 'is redirected to their homepage, and can sign out if they choose' do
+    visit new_session_path
+    fill_in 'Username', with: user.username
+    fill_in 'Password', with: user.password
+    click_button 'Submit'
+
+    expect(current_path).to eq(user_path(user))
+    expect(page).to have_text("#{user.username.capitalize}'s Page")
+
+    click_link 'Sign Out'
+    expect(current_path).to eq(root_path)
   end
 end


### PR DESCRIPTION
#### Refactor for readability and organization
* Extract out logic for rotating images into `ImageRotator` constructor function. This cleans up `skatepark-index.js`.
* `AJAX` module can now account for requests coming from both links and forms, and infers that automatically: if `$(event.target).attr('action')` has been defined it is a form, if not it is a link.
* Cleaned up `config/routes.rb` and removed old routes.
* Pulled everything out of `session_concern` except for the two helper methods `signed_in?` and `current_user` because they are currently needed in the view.

#### Minor additions / changes
* Added `awesome_print` and `quiet_assets` gems.
* Alphabetized `Gemfile`