### PR TITLE
Fixes/sequence factory girl

### DIFF
--- a/spec/controllers/skateparks_controller_spec.rb
+++ b/spec/controllers/skateparks_controller_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe SkateparksController, type: :controller do
   describe 'GET skateparks/:id/map_data' do
     it 'serves JSON object with skatepark and nearby_parks' do
-      skatepark = create(:skatepark)
-      nearby_skatepark = create(:skatepark, identifier: "alternate")
-      expected = skatepark.map_data.to_json
+      skateparks = create_list(:skatepark, 2)
+      expected = skateparks.first.map_data.to_json
 
-      get :map_data, id: skatepark.id
+      get :map_data, id: skateparks.first.id
       expect(response.body).to eq(expected)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe UsersController, type: :controller do
   describe 'GET users/:id/map_data' do
     it 'serves JSON object with favorites, visits, and both' do
       user = create(:user)
-      favorite_park = create(:skatepark, identifier: "candyland")
-      visited_park = create(:skatepark, identifier: "shroomland")
-      both_park = create(:skatepark, identifier: "cherryland")
-      create(:favorite, user_id: user.id, skatepark_id: favorite_park.id)
-      create(:visit, user_id: user.id, skatepark_id: visited_park.id)
-      create(:visit, user_id: user.id, skatepark_id: both_park.id)
-      create(:favorite, user_id: user.id, skatepark_id: both_park.id)
+      skateparks = create_list(:skatepark, 3)
+
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.first.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.second.id)
+
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.third.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.third.id)
 
       expected = user.map_data.to_json
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,21 +1,21 @@
 FactoryGirl.define do
-  #these tests depend on geocoding
-  #also, figure out how to make factories for join tables
   factory :skatepark do
     city 'Hayward'
     state 'California'
     address '520 E 3rd Ave, Hayward, CA'
     sequence(:identifier) { |i| "swag#{i}" }
-    latitude 53.0456
-    longitude -113.6547
+    latitude 35.0021
+    longitude -113.0051
     num_pics 3
 
-    trait :other do
-      city 'SW4GL4ND'
-      state 'California'
-      address '26251 Hesperian Blvd, Hayward, CA'
-      identifier 'SWAGNIFICENT'
-      num_pics 0
+    trait :nearby do
+      latitude 35.3045
+      longitude -113.0380
+    end
+
+    trait :far do
+      latitude 36.8021
+      longitude -113.0051
     end
   end
 
@@ -23,8 +23,13 @@ FactoryGirl.define do
     sequence(:username) { |n| "swaggy#{n}" }
     sequence(:email) { |n| "swag#{n}@swag.swag" }
     password 'swag'
+
+    trait :admin do
+      admin true
+    end
   end
 
+  # look into build_stubbed
   factory :favorite do
     user_id 420
     skatepark_id 420

--- a/spec/features/user_signs_in_spec.rb
+++ b/spec/features/user_signs_in_spec.rb
@@ -1,8 +1,9 @@
+require 'rails_helper'
 
 RSpec.feature 'User signs in' do
-  let(:user) { create(:user) }
-
   scenario 'tries to access admin dashboard and is redirected with error message' do
+    user = create(:user)
+
     visit new_session_path
     fill_in 'Username', with: user.username
     fill_in 'Password', with: user.password
@@ -15,6 +16,8 @@ RSpec.feature 'User signs in' do
   end
 
   scenario 'is redirected to their homepage, and can sign out if they choose' do
+    user = create(:user)
+
     visit new_session_path
     fill_in 'Username', with: user.username
     fill_in 'Password', with: user.password

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,16 +5,15 @@ RSpec.describe User, type: :model do
   context '#dups' do
     it 'returns an array of skateparks in common between favorite and visited' do
       user = create(:user)
-      favorite_park = create(:skatepark, identifier: "fantasyland")
-      visited_park = create(:skatepark, identifier: "veggieland")
-      both_park = create(:skatepark, identifier: "island")
-      create(:favorite, user_id: user.id, skatepark_id: favorite_park.id)
-      create(:visit, user_id: user.id, skatepark_id: visited_park.id)
-      create(:visit, user_id: user.id, skatepark_id: both_park.id)
-      create(:favorite, user_id: user.id, skatepark_id: both_park.id)
+      skateparks = create_list(:skatepark, 3)
 
-      expected = [both_park]
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.first.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.second.id)
 
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.third.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.third.id)
+
+      expected = [skateparks.third]
       expect(user.dups).to eq(expected)
     end
   end
@@ -22,13 +21,13 @@ RSpec.describe User, type: :model do
   context '#map_data' do
     it 'returns a hash with data needed for map generation' do
       user = create(:user)
-      favorite_park = create(:skatepark, identifier: "candyland")
-      visited_park = create(:skatepark, identifier: "shroomland")
-      both_park = create(:skatepark, identifier: "cherryland")
-      create(:favorite, user_id: user.id, skatepark_id: favorite_park.id)
-      create(:visit, user_id: user.id, skatepark_id: visited_park.id)
-      create(:visit, user_id: user.id, skatepark_id: both_park.id)
-      create(:favorite, user_id: user.id, skatepark_id: both_park.id)
+      skateparks = create_list(:skatepark, 3)
+
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.first.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.second.id)
+
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.third.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.third.id)
 
       expected = {
         skateparks: {
@@ -46,7 +45,7 @@ RSpec.describe User, type: :model do
 
   context '#is_admin?' do
     it 'returns true if user is an admin' do
-      user = create(:user, admin: true)
+      user = create(:user, :admin)
 
       expect(user.is_admin?).to eq(true)
     end
@@ -93,13 +92,13 @@ RSpec.describe User, type: :model do
   context '#first_marker_coordinates' do
     it 'returns lat long of first favorited or visited skatepark' do
       user = create(:user)
-      skatepark = create(:skatepark)
-      other = create(:skatepark, :other)
+      skateparks = create_list(:skatepark, 2)
 
-      create(:visit, user_id: user.id, skatepark_id: skatepark.id)
-      create(:favorite, user_id: user.id, skatepark_id: other.id)
+      create(:visit, user_id: user.id, skatepark_id: skateparks.first.id)
+      create(:favorite, user_id: user.id, skatepark_id: skateparks.second.id)
 
-      expect(user.first_marker_coordinates).to eq([other.latitude, other.longitude])
+      expect(user.first_marker_coordinates).to eq(
+        [skateparks.second.latitude, skateparks.second.longitude])
     end
 
     it 'returns SF EPICENTER if no park is found' do


### PR DESCRIPTION
* Refactor all tests to take advantage of `factory_girl`'s `create_list`. Also added in extra traits to factories to ease in readability of tests.

* Fixed failing seed `47571` by removing association creation with `user.favorite_parks << skatepark`. Not sure why this was failing on that particular seed but it could have something to do with us not using the `factory_girl` convention of creating associations.