### PR TITLE
Fixes/performance optimization

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -9,17 +9,15 @@ module Admin
     before_filter :authenticate_admin
 
     def authenticate_admin
-      unless admin_signed_in
-        flash[:notice] = 'You need admin authentication to access that.'
-        redirect_to new_session_path
-      end
-      # TODO Add authentication logic here.
+      return if admin_signed_in
+      flash[:notice] = 'You need admin authentication to access that.'
+      redirect_to new_session_path
     end
 
     private
 
       def admin_signed_in
-        current_user && current_user.is_admin?
+        current_user && current_user.admin?
       end
 
       def current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,21 +12,21 @@ class SessionsController < ApplicationController
 
   private
 
-  def login
-    if user_authenticated?
-      session[:id] = @user.id
-      redirect_to @user.is_admin? ? admin_root_path : @user
-    else
-      redirect_to new_session_path
+    def login
+      if user_authenticated?
+        session[:id] = @user.id
+        redirect_to @user.admin? ? admin_root_path : @user
+      else
+        redirect_to new_session_path
+      end
     end
-  end
 
-  def logout
-    session.clear
-  end
+    def logout
+      session.clear
+    end
 
-  def user_authenticated?
-    @user ||= User.where(username: params[:username]).first
-    @user && @user.authenticate(params[:password])
-  end
+    def user_authenticated?
+      @user ||= User.where(username: params[:username]).first
+      @user && @user.authenticate(params[:password])
+    end
 end

--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -5,7 +5,9 @@ class SkateparksController < ApplicationController
   end
 
   def show
-    @skatepark = Skatepark.find(params[:id])
+    @skatepark = Skatepark.includes(
+      :users_who_reviewed,
+      :users_who_rated).find(params[:id])
   end
 
   # skateparks by state via AJAX

--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -23,7 +23,7 @@ class SkateparksController < ApplicationController
 
   private
 
-  def skatepark_params
-    params.require(:skatepark).permit(:name, :city, :state, :rating, :designer, :builder, :opened, :address, :hours, :size, :notes, :helmet)
-  end
+    def skatepark_params
+      params.require(:skatepark).permit(:name, :city, :state, :rating, :designer, :builder, :opened, :address, :hours, :size, :notes, :helmet)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,8 @@ class UsersController < ApplicationController
   private
 
     def user_params
-      {username: params[:username], email: params[:email], password: params[:password] }
+      { username: params[:username],
+        email: params[:email],
+        password: params[:password] }
     end
 end

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -103,9 +103,9 @@ class Skatepark < ActiveRecord::Base
   def nearby_parks
     return [] unless has_coordinates?
     Skatepark.where(
-      "latitude BETWEEN #{latitude - 0.4} AND #{latitude + 0.4} AND "\
-      "longitude BETWEEN #{longitude - 0.4} AND #{longitude + 0.4} AND "\
-      "id != #{id}")
+      'latitude BETWEEN ? AND ?', latitude - 0.4, latitude + 0.4).where(
+        'longitude BETWEEN ? AND ?', longitude - 0.4, longitude + 0.4).where(
+          'id != ?', id)
   end
 
   private
@@ -113,6 +113,4 @@ class Skatepark < ActiveRecord::Base
     def delimit_size
       "#{number_with_delimiter(size, delimiter: ',')} sq ft" if size
     end
-
-
 end

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -73,11 +73,11 @@ class Skatepark < ActiveRecord::Base
   end
 
   def has_ratings?
-    ratings.length > 0
+    ratings.any?
   end
 
   def has_reviews?
-    reviews.length > 0
+    reviews.any?
   end
 
   def average_rating
@@ -100,16 +100,12 @@ class Skatepark < ActiveRecord::Base
     latitude && longitude
   end
 
-  def is_nearby?(skatepark)
-    return if skatepark.id == id
-    return unless skatepark.has_coordinates?
-    (latitude > skatepark.latitude - 0.4 && latitude < skatepark.latitude + 0.4) &&
-      (longitude > skatepark.longitude - 0.4 && longitude < skatepark.longitude + 0.4)
-  end
-
   def nearby_parks
     return [] unless has_coordinates?
-    Skatepark.all.select { |park| is_nearby?(park) }
+    Skatepark.where(
+      "latitude BETWEEN #{latitude - 0.4} AND #{latitude + 0.4} AND "\
+      "longitude BETWEEN #{longitude - 0.4} AND #{longitude + 0.4} AND "\
+      "id != #{id}")
   end
 
   private

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -17,24 +17,6 @@ class Skatepark < ActiveRecord::Base
   has_many :reviews, dependent: :destroy
   has_many :users_who_reviewed, through: :reviews, source: :user
 
-  def hashify_with_pictures
-    attributes.merge({
-      pictures: pictures,
-      firstPicture: first_picture
-    })
-  end
-
-  def map_data
-    {
-      skateparks: {
-        nearby: nearby_parks.map(&:hashify_with_pictures),
-        main: [hashify_with_pictures],
-      },
-      mapCenter: [latitude, longitude],
-      zoom: 9
-    }
-  end
-
   def self.search(target)
     where(
       'name LIKE ? OR city LIKE ? OR state LIKE ?',
@@ -45,72 +27,86 @@ class Skatepark < ActiveRecord::Base
   end
 
   def self.in_state(state)
-    where(state: state).order("city ASC")
-  end
-
-  def pictures
-    # should default num_pics to 0
-    if num_pics && num_pics > 0
-      (1..num_pics).map do |i|
-        "https://storage.googleapis.com/west-coast-skateparks/"\
-        "#{state}/#{identifier}-0#{i}.jpg"
-      end
-    else
-      []
-    end
-  end
-
-  def first_picture
-    pictures.first ? pictures.first : "https://storage.googleapis.com/west-coast-skateparks/logo-small.png"
-  end
-
-  def already_favorited_by?(user)
-    users_who_faved.include?(user)
-  end
-
-  def already_visited_by?(user)
-    users_who_visited.include?(user)
-  end
-
-  def has_ratings?
-    ratings.any?
-  end
-
-  def has_reviews?
-    reviews.any?
-  end
-
-  def average_rating
-    ratings.map(&:rating).reduce(:+)/ratings.length
-  end
-
-  def visibile_attributes
-    untouched = { 'Address' => self.address, 'Info' => self.info, 'Hours' => self.hours }
-    titleized = {
-      'Material' => material, 'Designer' => designer,
-      'Builder' => builder, 'Opened' => opened,
-      'Size' => delimit_size,
-      'Lights' => lights, 'Obstacles' => obstacles
-    }
-    titleized.each {|k, v| titleized[k] = v.titleize if v }
-    untouched.merge(titleized)
-  end
-
-  def has_coordinates?
-    latitude && longitude
+    where(state: state).order('city ASC')
   end
 
   def nearby_parks
-    return [] unless has_coordinates?
+    return [] unless coordinates?
     Skatepark.where(
       'latitude BETWEEN ? AND ?', latitude - 0.4, latitude + 0.4).where(
         'longitude BETWEEN ? AND ?', longitude - 0.4, longitude + 0.4).where(
           'id != ?', id)
   end
 
+  def map_data
+    {
+      skateparks: {
+        main: [hashify_with_pictures],
+        nearby: nearby_parks.map(&:hashify_with_pictures)
+      },
+      mapCenter: [latitude, longitude],
+      zoom: 9
+    }
+  end
+
+  def hashify_with_pictures
+    attributes.merge(
+      pictures: pictures,
+      firstPicture: first_picture)
+  end
+
+  def pictures
+    return [] unless num_pics && num_pics > 0
+    (1..num_pics).map { |i| "#{bucket_url}/#{state}/#{identifier}-0#{i}.jpg" }
+  end
+
+  def first_picture
+    pictures.first ? pictures.first : "#{bucket_url}/logo-small.png"
+  end
+
+  def favorited_by?(user)
+    users_who_faved.include?(user)
+  end
+
+  def visited_by?(user)
+    users_who_visited.include?(user)
+  end
+
+  def ratings?
+    ratings.any?
+  end
+
+  def reviews?
+    reviews.any?
+  end
+
+  def average_rating
+    ratings.map(&:rating).reduce(:+) / ratings.length
+  end
+
+  def coordinates?
+    latitude && longitude
+  end
+
+  def visibile_attributes # refactor
+    untouched = { 'Address' => address, 'Info' => info, 'Hours' => hours }
+    titleized = {
+      'Material' => material, 'Designer' => designer,
+      'Builder' => builder, 'Opened' => opened,
+      'Size' => delimit_size,
+      'Lights' => lights, 'Obstacles' => obstacles
+    }
+    titleized.each { |k, v| titleized[k] = v.titleize if v }
+    untouched.merge(titleized)
+  end
+
   private
-    # remove this method once data is properly structured
-    def delimit_size
+
+    def delimit_size # remove this method once data is properly structured
       "#{number_with_delimiter(size, delimiter: ',')} sq ft" if size
+    end
+
+    def bucket_url
+      'https://storage.googleapis.com/west-coast-skateparks'
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ActiveRecord::Base
   has_many :reviews
   has_many :reviewed_parks, through: :reviews, source: :skatepark
 
-  def is_admin?
+  def admin?
     admin
   end
 
@@ -29,11 +29,11 @@ class User < ActiveRecord::Base
     [37.7833, -122.4167] # SF BRO!!!!
   end
 
-  def has_favorites?
+  def favorites?
     favorites.any?
   end
 
-  def has_visits?
+  def visits?
     visits.any?
   end
 
@@ -52,5 +52,4 @@ class User < ActiveRecord::Base
   def dups
     @dups ||= favorite_parks & visited_parks
   end
-
 end

--- a/app/views/skateparks/show.html.erb
+++ b/app/views/skateparks/show.html.erb
@@ -70,11 +70,9 @@
 
       <% end %>
 
-      <% if @skatepark.nearby_parks.any? %>
-        <div class="center-text one-top">
-          <button id="toggle-nearby" class="ui button primary">Show Nearby Parks</button>
-        </div>
-      <% end %>
+      <div class="center-text one-top">
+        <button id="toggle-nearby" class="ui button primary">Show Nearby Parks</button>
+      </div>
       <!-- end skatepark-info column -->
     </div>
 

--- a/app/views/skateparks/show.html.erb
+++ b/app/views/skateparks/show.html.erb
@@ -14,7 +14,7 @@
       <!-- skatepark info -->
       <div class="ui segments">
         <!-- figure out new way to do this -->
-        <% if @skatepark.has_ratings? %>
+        <% if @skatepark.ratings? %>
           <div class="ui segment">
             <h4 class="ui header">User Rating</h4>
           </div>
@@ -44,7 +44,7 @@
     <!-- Map -->
 
 
-      <% if @skatepark.has_coordinates? %>
+      <% if @skatepark.coordinates? %>
         <div class='center-text two-top'>
           <form action="https://maps.google.com/maps" method="get" target="_blank">
             <div class="ui action input one-top">
@@ -61,7 +61,7 @@
           </div>
         </div>
 
-      <% else @skatepark.has_coordinates? %>
+      <% else @skatepark.coordinates? %>
 
         <div class="map-missing">
           <img src="" >
@@ -93,7 +93,7 @@
 
       <% if logged_in? %>
         <div class="button-container center-text">
-          <% visited = @skatepark.already_visited_by?(current_user) %>
+          <% visited = @skatepark.visited_by?(current_user) %>
           <% visibility = visited ? "" : "hidden" %>
 
           <!-- visit button -->
@@ -105,7 +105,7 @@
 
           <!-- favorite button -->
           <div class="fav-container inline-block one-top">
-            <% favorited = @skatepark.already_favorited_by?(current_user) %>
+            <% favorited = @skatepark.favorited_by?(current_user) %>
             <%= render partial: "remove_favorite_button", locals: {favorited: favorited, skatepark: @skatepark} %>
             <%= render partial: "add_favorite_button", locals: {favorited: favorited, skatepark: @skatepark} %>
           </div>
@@ -125,7 +125,7 @@
 
       <!-- Reviews -->
       <div class="written-review-container">
-        <% if @skatepark.has_reviews? %>
+        <% if @skatepark.reviews? %>
           <h4>Reviews</h4>
           <div class="ui comments">
             <% @skatepark.reviews.each do |review| %>
@@ -165,7 +165,7 @@
   </div>
 </div>
 
-<% if @skatepark.has_coordinates? %>
+<% if @skatepark.coordinates? %>
 
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_KEY'] %>&callback=initMap"
       async defer>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,13 +36,13 @@
           <div id="map" class="user-map"></div>
         </div>
         <div class="center-text two-top">
-          <% if @user.has_favorites? %>
+          <% if @user.favorites? %>
             <button id="toggle-favorite" class="ui button primary">Hide Favorites</button>
           <% end %>
-          <% if @user.has_visits? %>
+          <% if @user.visits? %>
             <button id="toggle-visited" class="ui button primary">Hide Visited</button>
           <% end %>
-          <% if @user.has_favorites? && @user.has_visits? %>
+          <% if @user.favorites? && @user.visits? %>
             <button id="toggle-both" class="ui button primary">Hide Thrashed</button>
           <% end %>
         </div>

--- a/spec/models/skatepark_spec.rb
+++ b/spec/models/skatepark_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Skatepark, type: :model do
   context '#map_data' do
     it 'returns a hash with data needed for map generation' do
       skatepark = create(:skatepark)
-      create(:skatepark, identifier: "areolaland")
+      create(:skatepark, identifier: 'areolaland')
 
       expected = {
         skateparks: {
           nearby: skatepark.nearby_parks.map(&:hashify_with_pictures),
-          main: [skatepark.hashify_with_pictures],
+          main: [skatepark.hashify_with_pictures]
         },
         mapCenter: [skatepark.latitude, skatepark.longitude],
         zoom: 9
@@ -24,7 +24,7 @@ RSpec.describe Skatepark, type: :model do
       expected = {
         skateparks: {
           nearby: [],
-          main: [skatepark.hashify_with_pictures],
+          main: [skatepark.hashify_with_pictures]
         },
         mapCenter: [skatepark.latitude, skatepark.longitude],
         zoom: 9
@@ -32,8 +32,6 @@ RSpec.describe Skatepark, type: :model do
 
       expect(skatepark.map_data).to eq(expected)
     end
-
-
   end
 
   context '.in_state' do
@@ -52,14 +50,10 @@ RSpec.describe Skatepark, type: :model do
   context '#pictures' do
     it 'returns an array with the correct photo urls' do
       skatepark = create(:skatepark)
-      expect(skatepark.pictures).to eq(
-        [
-          generate_image_url(skatepark, 1),
-          generate_image_url(skatepark, 2),
-          generate_image_url(skatepark, 3),
-        ]
-      )
-
+      expect(skatepark.pictures).to eq([
+        generate_image_url(skatepark, 1),
+        generate_image_url(skatepark, 2),
+        generate_image_url(skatepark, 3)])
     end
 
     it 'returns an empty array if no pics' do
@@ -76,7 +70,7 @@ RSpec.describe Skatepark, type: :model do
 
     it 'should return the wcs logo if no image' do
       skatepark = create(:skatepark, num_pics: 0)
-      expect(skatepark.first_picture).to eq("https://storage.googleapis.com/west-coast-skateparks/logo-small.png")
+      expect(skatepark.first_picture).to eq('https://storage.googleapis.com/west-coast-skateparks/logo-small.png')
     end
   end
 
@@ -91,53 +85,53 @@ RSpec.describe Skatepark, type: :model do
     end
   end
 
-  context '#has_coordinates?' do
+  context '#coordinates?' do
     it 'returns true if the skatepark has latitude and longitude' do
       skatepark = create(:skatepark)
-      expect(skatepark.has_coordinates?).to be_truthy
+      expect(skatepark.coordinates?).to be_truthy
     end
 
     it 'returns false if the skatepark does not have latitude or longitude' do
       skatepark = create(:skatepark, latitude: nil)
-      expect(skatepark.has_coordinates?).to be_falsey
+      expect(skatepark.coordinates?).to be_falsey
     end
   end
 
-  context '#already_favorited_by?' do
+  context '#favorited_by?' do
     it 'returns true if skatepark has been favorited by user' do
       user = create(:user)
       skatepark = create(:skatepark)
       create(:favorite, user_id: user.id, skatepark_id: skatepark.id)
 
-      expect(skatepark.already_favorited_by?(user)).to be true
+      expect(skatepark.favorited_by?(user)).to be true
     end
 
     it 'returns false if skatepark has not been favorited by user' do
       user = create(:user)
       skatepark = create(:skatepark)
 
-      expect(skatepark.already_favorited_by?(user)).to be false
+      expect(skatepark.favorited_by?(user)).to be false
     end
   end
 
-  context '#already_visited_by?' do
+  context '#visited_by?' do
     it 'returns true if skatepark has been visited by user' do
       user = create(:user)
       skatepark = create(:skatepark)
       create(:visit, user_id: user.id, skatepark_id: skatepark.id)
 
-      expect(skatepark.already_visited_by?(user)).to be true
+      expect(skatepark.visited_by?(user)).to be true
     end
 
     it 'returns false if skatepark has not been visited by user' do
       user = create(:user)
       skatepark = create(:skatepark)
 
-      expect(skatepark.already_visited_by?(user)).to be false
+      expect(skatepark.visited_by?(user)).to be false
     end
   end
 
-  context '#has_ratings?' do
+  context '#ratings?' do
     it 'returns true when a skatepark has ratings' do
       user = create(:user)
       skatepark = create(:skatepark)
@@ -145,11 +139,11 @@ RSpec.describe Skatepark, type: :model do
       Rating.create(
         user_id: user.id, skatepark_id: skatepark.id, rating: 5)
 
-      expect(skatepark.has_ratings?).to be true
+      expect(skatepark.ratings?).to be true
     end
   end
 
-  context '#has_reviews?' do
+  context '#reviews?' do
     it 'returns true when a skatepark has reviews' do
       user = create(:user)
       skatepark = create(:skatepark)
@@ -157,7 +151,7 @@ RSpec.describe Skatepark, type: :model do
       Review.create(
         user_id: user.id, skatepark_id: skatepark.id, review: 'meh')
 
-      expect(skatepark.has_reviews?).to be true
+      expect(skatepark.reviews?).to be true
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-
   context '#dups' do
     it 'returns an array of skateparks in common between favorite and visited' do
       user = create(:user)
@@ -43,49 +42,49 @@ RSpec.describe User, type: :model do
     end
   end
 
-  context '#is_admin?' do
+  context '#admin?' do
     it 'returns true if user is an admin' do
       user = create(:user, :admin)
 
-      expect(user.is_admin?).to eq(true)
+      expect(user.admin?).to eq(true)
     end
 
     it 'returns false if user is not an admin' do
       user = create(:user)
 
-      expect(user.is_admin?).to eq(false)
+      expect(user.admin?).to eq(false)
     end
   end
 
-  context '#has_favorites?' do
+  context '#favorites?' do
     it 'returns true if user has favorites' do
       user = create(:user)
       skatepark = create(:skatepark)
       create(:favorite, user_id: user.id, skatepark_id: skatepark.id)
 
-      expect(user.has_favorites?).to eq(true)
+      expect(user.favorites?).to eq(true)
     end
 
     it 'returns false if user does not have favorites' do
       user = create(:user)
 
-      expect(user.has_favorites?).to eq(false)
+      expect(user.favorites?).to eq(false)
     end
   end
 
-  context '#has_visits?' do
+  context '#visits?' do
     it 'returns true if user has visits' do
       user = create(:user)
       skatepark = create(:skatepark)
       create(:visit, user_id: user.id, skatepark_id: skatepark.id)
 
-      expect(user.has_visits?).to eq(true)
+      expect(user.visits?).to eq(true)
     end
 
     it 'returns false if user does not have visits' do
       user = create(:user)
 
-      expect(user.has_visits?).to eq(false)
+      expect(user.visits?).to eq(false)
     end
   end
 


### PR DESCRIPTION
### Changes
Optimize `Skatepark#show` page performance by eager loading `users_who_reviewed` `users_who_rated`, and selecting `nearby_parks` with raw SQL query.

### Why it was slow af
`Skatepark#nearby_parks` was grabbing all of the skateparks and then selecting the ones that met our criteria for "nearby". Now skateparks are being selected only if they are within our range of specified `latitude` and `longitude`. This greatly improves page load.

Another issue which was `STUPID AF` :persevere: was we were calling `@skatepark.nearby_parks.any?` in the view as well as the `/skateparks/:id/map_data` route.. Which was essentailly reloading all skateparks again once we hit the `show` page. Removing this added a huuuge boost to page load.

### N + 1 Queries
The `Skatepark#show` action now [eager loads](https://robots.thoughtbot.com/active-record-eager-loading-with-query-objects-and-decorators) `:users_who_reviewed` and `:users_who_rated` because before we had a massive N+1 query sitch coming from the `skateparks/_review.html.erb` partial. *refer to photo

Before:
<img width="882" alt="screen shot 2016-02-14 at 10 45 43 am" src="https://cloud.githubusercontent.com/assets/10933051/13035561/4e6cbf22-d308-11e5-8354-0b8cb504b1f6.png">

After:
<img width="1294" alt="screen shot 2016-02-14 at 10 46 47 am" src="https://cloud.githubusercontent.com/assets/10933051/13035563/529c356e-d308-11e5-93c9-b7606a7dd355.png">

This doesn't give us a noticeable performance boost at the moment, but as our app scales this will keep us from running into issues with massive memory usage.

### Syntax
I'm gonna stop being lazy piece of shit and start configuring my syntax checker to actually do its job, so I decided to clean up some of the syntax to adhere to some principles. see [this commit](https://github.com/alookatommorow/west-coast-skateparks/commit/6ecfb7292ab64d11db1678bdc57dab0cfa830185)
