### PR TITLE
Fix url parsing bug in init map

### DIFF
--- a/app/assets/javascripts/modules/init-map.js
+++ b/app/assets/javascripts/modules/init-map.js
@@ -1,6 +1,6 @@
 function initMap() {
   var location = window.location.href.split('/');
-  var id = location.pop();
+  var id = location.pop().split("?")[0];
   var resourceName = location.pop();
   $.ajax({
     url: '/'+resourceName+'/'+id+'/map_data'
@@ -12,7 +12,7 @@ function initMap() {
 }
 
 var generateMarkers = function(response) {
-  var mapCenter = {lat: response.mapCenter[0], lng: response.mapCenter[1]}
+  var mapCenter = {lat: response.mapCenter[0], lng: response.mapCenter[1]};
 
   var map = new google.maps.Map(document.getElementById('map'), {
     zoom: response.zoom,
@@ -20,4 +20,4 @@ var generateMarkers = function(response) {
   });
 
   new MarkerGenerator(map, response.skateparks).generateMarkers().showButtons();
-}
+};


### PR DESCRIPTION
Our current method of getting the resource's id (`skatepark_id`, `user_id`) in `init-map.js` requires us to split the current page's url string. The `fb_login` param that was added for redirection from facebook oauth caused us to pass in an `id` of (example) `1?from_fb=true` instead of `1`. This was fixed by adding an extra action to the `var id` assignment in `init-map.js`. We split the location string again by `'?'` and select the first element to remove any parameters that come after the id.