### PR TITLE
add rack ssl enforcer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'less-rails-semantic_ui', '~> 2.1.8.2'
 gem 'paperclip', '~> 4.3'
 gem 'pg'
 gem 'puma'
+gem 'rack-ssl-enforcer'
 gem 'rails_12factor', group: :production
 gem 'sass-rails', '~> 5.0'
 gem 'slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
+    rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.6)
@@ -324,6 +325,7 @@ DEPENDENCIES
   pry-rails
   puma
   quiet_assets
+  rack-ssl-enforcer
   rails (= 4.2.6)
   rails_12factor
   rake

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,6 @@ module WestCoastSkateparks
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.active_record.raise_in_transactional_callbacks = true
+    config.middleware.use Rack::SslEnforcer, except_environments: ['development', 'test']
   end
 end


### PR DESCRIPTION
#### Rack SSL Enforcer

- Add gem `rack-ssl-enforcer`
- Update `config/application.rb` to use SSL enforcer in all but `test` and `development` environments
- Use of `https://` now enforced for across all requests in `prod`