### PR TITLE
Seo upgrade

### DIFF
--- a/app/assets/javascripts/components/SearchContainer.js.jsx
+++ b/app/assets/javascripts/components/SearchContainer.js.jsx
@@ -14,7 +14,7 @@ var SearchContainer = React.createClass({
 
   filterAndAddIndexOfMatch: function(query) {
     return function(skatepark) {
-      if (skatepark.location) { // to prevent search from breaking during skatepark creation
+      if (skatepark.location) { // in case no location
         if (skatepark.name.indexOf(query) !== -1 || skatepark.location.city.indexOf(query) !== -1) {
           skatepark.string = skatepark.name+", "+skatepark.location.city+", "+stateDisplay[skatepark.location.state];
           skatepark.matchIndex = skatepark.string.indexOf(query);

--- a/app/assets/javascripts/components/SearchResults.js.jsx
+++ b/app/assets/javascripts/components/SearchResults.js.jsx
@@ -27,7 +27,7 @@ var SearchResults = React.createClass({
   },
 
   selectFirstResult: function() {
-    var firstResult = document.getElementById("react-search-results").firstChild;
+    var firstResult = document.getElementById("search-results-list").firstChild;
     if (firstResult) {
       this.addSelect(firstResult);
     }
@@ -68,7 +68,7 @@ var SearchResults = React.createClass({
           this.visitSelectedLink();
         break;
 
-        case 27:
+        case 27: // esc
           this.props.exitResults();
         break;
 
@@ -96,32 +96,40 @@ var SearchResults = React.createClass({
   render: function(){
 
     var createBoldString = function(string, matchIndex, query) {
-      var output = titleize(string);
-      var first = output.slice(0, matchIndex);
-      var bold = output.slice(matchIndex, matchIndex + query.length);
-      var last = output.slice(matchIndex + query.length);
+      var output = titleize(string),
+          first = output.slice(0, matchIndex),
+          bold = output.slice(matchIndex, matchIndex + query.length),
+          last = output.slice(matchIndex + query.length);
       return <span>{first}<span className="bold">{bold}</span>{last}</span>;
     }
 
-    var resultDisplay, boldedResultDisplay, link, results;
+    var numResults = this.props.results.length,
+        matchText = "Matches",
+        resultsDisplay,
+        boldedResultDisplay,
+        link,
+        numResultsDisplay;
 
     if (this.props.query) {
-      if (this.props.results.length === 0) {
-        results = <div className="item no-results"><span className="bold">No Results</span></div>
-      } else if (this.props.results.length > 0) {
-        results = this.props.results.map(function(skatepark) {
-          boldedResultDisplay = createBoldString(skatepark.string, skatepark.matchIndex, this.props.query);
-          link = "/skateparks/"+skatepark.id+"-"+skatepark.name.replace(/\//g, "-").replace(/\./, "").split(" ").join("-")+"-"+skatepark.location.city.replace(/\(|\)|\./g, "").split(" ").join("-")+"-"+skatepark.location.state;
-          return <div className="item" key={skatepark.id} onMouseEnter={this.deselectActive} onClick={this.handleClick}>
-                  <a href={link}>{boldedResultDisplay}</a>
-                </div>
-        }.bind(this));
+      if (numResults === 1) {
+        matchText = "Match"
       }
+      numResultsDisplay = <div className="item num-results"><span className="bold">{numResults} {matchText}</span></div>;
+      resultsDisplay = this.props.results.map(function(skatepark) {
+        boldedResultDisplay = createBoldString(skatepark.string, skatepark.matchIndex, this.props.query);
+        link = "/skateparks/"+skatepark.id+"-"+skatepark.name.replace(/\//g, "-").replace(/\./, "").split(" ").join("-")+"-"+skatepark.location.city.replace(/\(|\)|\./g, "").split(" ").join("-")+"-"+skatepark.location.state;
+        return <div className="item" key={skatepark.id} onMouseEnter={this.deselectActive} onClick={this.handleClick}>
+                <a href={link}>{boldedResultDisplay}</a>
+              </div>
+      }.bind(this));
     }
 
     return (
       <div id="react-search-results" className="divided selection list" onKeyDown={this.handleKeyDown} onMouseLeave={this.handleMouseLeave} >
-        {results}
+        {numResultsDisplay}
+        <div id="search-results-list">
+          {resultsDisplay}
+        </div>
       </div>
     );
   }

--- a/app/assets/javascripts/components/SearchResults.js.jsx
+++ b/app/assets/javascripts/components/SearchResults.js.jsx
@@ -111,7 +111,7 @@ var SearchResults = React.createClass({
       } else if (this.props.results.length > 0) {
         results = this.props.results.map(function(skatepark) {
           boldedResultDisplay = createBoldString(skatepark.string, skatepark.matchIndex, this.props.query);
-          link = "/skateparks/"+skatepark.id+"-"+skatepark.name.replace(/\//g, "-").replace(/\./, "").split(" ").join("-")+"-"+skatepark.location.city.replace(/\(|\)|\./g, "").split(" ").join("-");
+          link = "/skateparks/"+skatepark.id+"-"+skatepark.name.replace(/\//g, "-").replace(/\./, "").split(" ").join("-")+"-"+skatepark.location.city.replace(/\(|\)|\./g, "").split(" ").join("-")+"-"+skatepark.location.state;
           return <div className="item" key={skatepark.id} onMouseEnter={this.deselectActive} onClick={this.handleClick}>
                   <a href={link}>{boldedResultDisplay}</a>
                 </div>

--- a/app/assets/javascripts/skatepark-photos.js
+++ b/app/assets/javascripts/skatepark-photos.js
@@ -67,8 +67,8 @@ $(document).ready(function() {
   });
 
   //key navigation logic
-  if ($("[data-dashboard-link='#skatepark-photos']").hasClass("selected")) {
-    $(document).on('keydown', function(event) {
+  $(document).on('keydown', function(event) {
+    if (!$("#react-search-input").is(":focus") && $("[data-dashboard-link='#skatepark-photos']").hasClass("selected") ) {
       event = event || window.event;
       switch(event.which || event.keyCode) {
         case 37: // left
@@ -81,6 +81,6 @@ $(document).ready(function() {
 
         default: return; // exit this handler for other keys
       }
-    });
-  }
+    }
+  });
 });

--- a/app/assets/stylesheets/styles/layout.scss
+++ b/app/assets/stylesheets/styles/layout.scss
@@ -146,3 +146,9 @@ input, textarea {
   box-sizing: border-box;
 }
 
+// for react search
+.bold {
+  font-weight: bold;
+  color: $orange;
+}
+

--- a/app/assets/stylesheets/styles/skateparks/_header.scss
+++ b/app/assets/stylesheets/styles/skateparks/_header.scss
@@ -18,7 +18,8 @@
         margin-bottom: 5px;
       }
 
-      h3 {
+      h2 {
+        font-size: 1.28rem;
         margin: 0;
         font-weight: lighter;
         color: white;

--- a/app/assets/stylesheets/styles/skateparks/searches/search.scss
+++ b/app/assets/stylesheets/styles/skateparks/searches/search.scss
@@ -67,6 +67,10 @@
       max-height: 750px;
       overflow-y: auto;
 
+      .num-results {
+        text-align: center;
+      }
+
       .item {
         color: black;
 
@@ -74,7 +78,7 @@
           color: black;
         }
 
-        &.active:not(.no-results) {
+        &.active:not(.num-results) {
           background-color: $gray;
         }
       }

--- a/app/helpers/skatepark_helper.rb
+++ b/app/helpers/skatepark_helper.rb
@@ -13,6 +13,10 @@ module SkateparkHelper
     "#{@skatepark.name.titleize} - #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]}"
   end
 
+  def skatepark_description
+    "#{@skatepark.name.titleize} in #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]}"
+  end
+
   def state_abbrev
     {
       "california" => "CA",

--- a/app/helpers/skatepark_helper.rb
+++ b/app/helpers/skatepark_helper.rb
@@ -9,7 +9,7 @@ module SkateparkHelper
     }
   end
 
-  def skatepark_meta_title
+  def skatepark_og_meta_title
     "#{@skatepark.name.titleize} - #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]}"
   end
 

--- a/app/helpers/skatepark_helper.rb
+++ b/app/helpers/skatepark_helper.rb
@@ -14,7 +14,7 @@ module SkateparkHelper
   end
 
   def skatepark_description
-    "#{@skatepark.name.titleize} in #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]}"
+    "#{@skatepark.name.titleize} in #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]} - photos, map, and info"
   end
 
   def state_abbrev

--- a/app/views/application/_default_metatags.slim
+++ b/app/views/application/_default_metatags.slim
@@ -1,13 +1,1 @@
-meta name="twitter:card" content="summary_large_image"
-/meta name="twitter:site" content="@dont_have_one"
-meta name="twitter:title" content="West Coast Skateparks"
-meta name="twitter:image" content=image_url("open_graph/temporary_main_image.png")
-meta name="twitter:description" content="Your guide to the skateparks of the Western U.S."
-
-meta property="og:title" content="West Coast Skateparks"
-meta property="og:url" content=request.original_url
-meta property="og:image" content=image_url("open_graph/temporary_main_image.png")
-meta property="og:description" content="Your guide to the skateparks of the Western U.S."
-meta property="fb:app_id" content="1520128344956383"
-
 meta name="description" content="The #1 source for skatepark information in the Western U.S., featuring pictures, maps, info, and everything you need to find a skatepark near you."

--- a/app/views/application/_default_metatags.slim
+++ b/app/views/application/_default_metatags.slim
@@ -9,3 +9,5 @@ meta property="og:url" content=request.original_url
 meta property="og:image" content=image_url("open_graph/temporary_main_image.png")
 meta property="og:description" content="Your guide to the skateparks of the Western U.S."
 meta property="fb:app_id" content="1520128344956383"
+
+meta name="description" content="The #1 source for skatepark information in the Western U.S., featuring pictures, maps, info, and everything you need to find a skatepark near you."

--- a/app/views/application/_default_og_metatags.slim
+++ b/app/views/application/_default_og_metatags.slim
@@ -1,0 +1,11 @@
+meta name="twitter:card" content="summary_large_image"
+/meta name="twitter:site" content="@dont_have_one"
+meta name="twitter:title" content="West Coast Skateparks"
+meta name="twitter:image" content=image_url("open_graph/temporary_main_image.png")
+meta name="twitter:description" content="Your guide to the skateparks of the Western U.S."
+
+meta property="og:title" content="West Coast Skateparks"
+meta property="og:url" content=request.original_url
+meta property="og:image" content=image_url("open_graph/temporary_main_image.png")
+meta property="og:description" content="Your guide to the skateparks of the Western U.S."
+meta property="fb:app_id" content="1520128344956383"

--- a/app/views/buttercms/posts/index.html.erb
+++ b/app/views/buttercms/posts/index.html.erb
@@ -1,3 +1,10 @@
+<% content_for :page_title do %>
+  <title>News | West Coast Skateparks</title>
+<% end %>
+<% content_for :metadata do %>
+  <meta name="description" content="News and updates on fresh concrete getting poured on the West Coast">
+<% end %>
+
 <%= render partial: "header" %>
 <div class="divided selection list posts-index-container">
   <!-- List of posts -->

--- a/app/views/buttercms/posts/show.html.erb
+++ b/app/views/buttercms/posts/show.html.erb
@@ -1,5 +1,9 @@
-<%= content_for :html_title, @post.seo_title %>
-<%= content_for :meta_description, @post.meta_description %>
+<% content_for :page_title do %>
+    <title><%= @post.seo_title %></title>
+<% end %>
+<% content_for :metadata do %>
+ <meta name="description" content="<%= @post.meta_description %>"%>
+<% end %>
 
 <%= render partial: "header" %>
 

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -8,6 +8,10 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = csrf_meta_tags
     = favicon_link_tag 'favicon.ico'
+    - if content_for? :og_metadata
+      = yield :og_metadata
+    - else
+      = render "default_og_metatags"
     - if content_for? :metadata
       = yield :metadata
     - else

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -8,10 +8,10 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true
     = csrf_meta_tags
     = favicon_link_tag 'favicon.ico'
-    - if content_for? :og_metadata
-      = yield :og_metadata
+    - if content_for? :metadata
+      = yield :metadata
     - else
-      = render "default_open_graph_metatags"
+      = render "default_metatags"
 
     meta name='viewport' content='width=device-width, initial-scale=1'
   body

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,3 +1,7 @@
+<% content_for :page_title do %>
+  <title>About | West Coast Skateparks</title>
+<% end %>
+
 <div class="about-page">
   <div class="skatepark-info">
     <div class="raised segment category">

--- a/app/views/skateparks/_header.slim
+++ b/app/views/skateparks/_header.slim
@@ -1,7 +1,7 @@
 header.skatepark-show-header style="background-image: linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('#{skatepark.hero.url}');"
   .header-skatepark-name
     h1= skatepark.name.titleize
-    h3 #{skatepark.city.titleize}, #{skatepark.state.capitalize}
+    h2 #{skatepark.city.titleize}, #{skatepark.state.capitalize}
   .header-skatepark-arrows
     = link_to skatepark_path(skatepark.previous_park), class: "left-arrow" do
       i.fa.fa-angle-left

--- a/app/views/skateparks/_photos.slim
+++ b/app/views/skateparks/_photos.slim
@@ -9,7 +9,7 @@
       .carousel-image-container
         - skatepark.skatepark_images.each do |image|
           .skatepark-show-image
-            img src="#{image.photo.url}"
+            img src="#{image.photo.url}" alt="#{skatepark.name}, #{skatepark.city}, #{skatepark.state}"
       .photo-thumbnails
         - skatepark.skatepark_images.each do |image|
           .skatepark-show-thumbnail

--- a/app/views/skateparks/index.slim
+++ b/app/views/skateparks/index.slim
@@ -28,6 +28,12 @@
 a#back-to-top href="#top"
   i#up-arrow.fa.fa-angle-double-up
 
+= content_for :page_title
+  title="Skateparks | West Coast Skateparks"
+
+= content_for :metadata
+  meta name="description" content="Browse all skateparks by state and city"
+
 = content_for :analytics_event
   javascript:
     analytics.page("Skateparks Index");

--- a/app/views/skateparks/show.slim
+++ b/app/views/skateparks/show.slim
@@ -19,9 +19,11 @@
   meta property="og:description" content=@skatepark.formatted_address
   meta property="fb:app_id" content="1520128344956383"
 
+  meta name="description" content=skatepark_description
+
 = content_for :analytics_event
   javascript:
     analytics.page("Skatepark", #{raw skatepark_json(@skatepark)});
 
 = content_for :page_title
-  title= "#{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{@skatepark.state.capitalize} | West Coast Skateparks"
+  title= "#{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]} | West Coast Skateparks"

--- a/app/views/skateparks/show.slim
+++ b/app/views/skateparks/show.slim
@@ -24,4 +24,4 @@
     analytics.page("Skatepark", #{raw skatepark_json(@skatepark)});
 
 = content_for :page_title
-  title= "West Coast Skateparks | #{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{@skatepark.state.capitalize} "
+  title= "#{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{@skatepark.state.capitalize} | West Coast Skateparks"

--- a/app/views/skateparks/show.slim
+++ b/app/views/skateparks/show.slim
@@ -9,21 +9,22 @@
 = content_for :og_metadata
   meta name="twitter:card" content="summary_large_image"
   /meta name="twitter:site" content="@dont_have_one"
-  meta name="twitter:title" content=skatepark_meta_title
+  meta name="twitter:title" content=skatepark_og_meta_title
   meta name="twitter:image" content=@skatepark.hero.url
   meta name="twitter:description" content=@skatepark.formatted_address
 
-  meta property="og:title" content=skatepark_meta_title
+  meta property="og:title" content=skatepark_og_meta_title
   meta property="og:url" content=request.original_url
   meta property="og:image" content=@skatepark.hero.url
   meta property="og:description" content=@skatepark.formatted_address
   meta property="fb:app_id" content="1520128344956383"
 
+= content_for :metadata
   meta name="description" content=skatepark_description
+
+= content_for :page_title
+  title="#{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]} | West Coast Skateparks"
 
 = content_for :analytics_event
   javascript:
     analytics.page("Skatepark", #{raw skatepark_json(@skatepark)});
-
-= content_for :page_title
-  title= "#{@skatepark.name.titleize}, #{@skatepark.city.titleize}, #{state_abbrev[@skatepark.state]} | West Coast Skateparks"

--- a/spec/features/visitor_searches_skatepark_spec.rb
+++ b/spec/features/visitor_searches_skatepark_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Visitor searches skatepark' do
     find('.display-search').click
 
     fill_in 'react-search-input', with: "Turd nugget"
-    expect(page).to have_text("No Results")
+    expect(page).to have_text("0 Matches")
     fill_in 'react-search-input', with: skatepark.name
     expect(page).to have_text(skatepark.name.titleize)
 


### PR DESCRIPTION
## SEO Upgrade
After doing a little reading on SEO changed/added a couple things:

- Alt attributes for images (helps with web & image searches)
- Add logic for non OG meta data
- Modify show page titles so skatepark name, city and state come before "West Coast Skateparks"
- Add meta descriptions to various pages (this is the text that appears below the link heading in a Google search, we didn't have any before)

As a bonus, added the following to the search feature:
- A number of matches count at the top of the results (to help convince users they are seeing all the results)
- Orange highlighting of matched query
