### PR TITLE
Add status column to skateparks

### DIFF
--- a/app/assets/stylesheets/styles/skateparks/_show.scss
+++ b/app/assets/stylesheets/styles/skateparks/_show.scss
@@ -4,6 +4,29 @@
   padding-top: 49px;
   min-height: 100vh;
 
+  &.closed {
+    height: calc(100vh - 49px);
+    overflow: hidden;
+  }
+
+  .closed-overlay {
+    position: absolute;
+    background-color: gray;
+    height: calc(100vh - 49px);
+    width: 100%;
+    opacity: 0.7;
+    z-index: 98;
+  }
+
+  .closed-stamp {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 80%;
+    z-index: 99;
+  }
+
   @media #{$mobile} {
     background: white;
     display: flex;

--- a/app/helpers/skatepark_helper.rb
+++ b/app/helpers/skatepark_helper.rb
@@ -16,7 +16,12 @@ module SkateparkHelper
   end
 
   def skatepark_og_meta_title(skatepark)
-    "#{skatepark} - #{skatepark.city.titleize}, #{STATE_ABBREVS[skatepark.state]}"
+    title = "#{skatepark} - #{skatepark.city.titleize}, #{STATE_ABBREVS[skatepark.state]}"
+    if skatepark.open?
+      title
+    else
+      "[CLOSED] - #{title}"
+    end
   end
 
   def skatepark_description(skatepark)

--- a/app/helpers/skatepark_helper.rb
+++ b/app/helpers/skatepark_helper.rb
@@ -17,11 +17,9 @@ module SkateparkHelper
 
   def skatepark_og_meta_title(skatepark)
     title = "#{skatepark} - #{skatepark.city.titleize}, #{STATE_ABBREVS[skatepark.state]}"
-    if skatepark.open?
-      title
-    else
-      "[CLOSED] - #{title}"
-    end
+    return title if skatepark.open?
+
+    "[CLOSED] - #{title}"
   end
 
   def skatepark_description(skatepark)

--- a/app/javascript/pages/skateparks/show/index.tsx
+++ b/app/javascript/pages/skateparks/show/index.tsx
@@ -7,6 +7,7 @@ import { Reviews } from './Reviews';
 import { GMap } from '../../../components/GoogleMap';
 import { Photos } from './Photos';
 import { Flash } from '../../../components/Flash';
+import { classNames } from '../../../utils/styles';
 
 const INFO_ATTRS = [
   'material',
@@ -44,6 +45,9 @@ const INFO_ICONS = {
   lights: 'fa-lightbulb',
 };
 
+const STAMP_URL =
+  'https://west-coast-skateparks.s3.us-west-1.amazonaws.com/closed-stamp.png';
+
 type SkateparksShowProps = {
   skatepark: Skatepark;
   hasFavorited: boolean;
@@ -72,8 +76,19 @@ export const SkateparksShow = ({
   const handleFlashClose = () => setError('');
 
   return (
-    <div className="skatepark-show-container">
+    <div
+      className={classNames('skatepark-show-container', {
+        closed: skatepark.status === 'closed',
+      })}
+    >
       <Flash type="error" message={error} onClose={handleFlashClose} />
+      {skatepark.status === 'closed' && (
+        <>
+          <div className="closed-overlay" />
+          <img className="closed-stamp" src={STAMP_URL} />
+        </>
+      )}
+
       <div className="sidebar">
         <div className="fav-visit-indicators">
           <h1>{titleize(skatepark.name)}</h1>
@@ -128,11 +143,13 @@ export const SkateparksShow = ({
       </div>
       <div className="map-photos">
         <Photos photos={photos} />
-        <GMap
-          resourceName="skatepark"
-          resourceId={Number(skatepark.id)}
-          mapKey={mapKey}
-        />
+        {skatepark.status === 'open' && (
+          <GMap
+            resourceName="skatepark"
+            resourceId={Number(skatepark.id)}
+            mapKey={mapKey}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/javascript/types/index.ts
+++ b/app/javascript/types/index.ts
@@ -21,6 +21,7 @@ export type Skatepark = {
   lights?: string;
   info?: string;
   average_rating?: number;
+  status?: 'open' | 'closed';
 };
 
 export type SkateparkAttr = keyof Skatepark;

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -34,6 +34,7 @@
 #  slug                   :string
 #  stars                  :float
 #  state                  :string           not null
+#  status                 :integer          default("open"), not null
 #  video_url              :string
 #  zip_code               :string
 #  created_at             :datetime
@@ -88,6 +89,8 @@ class Skatepark < ActiveRecord::Base
     'oregon' => 'OR',
     'washington' => 'WA'
   }.freeze
+
+  enum status: { open: 0, closed: 1 }
 
   STARS = [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].freeze
 

--- a/app/serializers/skateparks/show_serializer.rb
+++ b/app/serializers/skateparks/show_serializer.rb
@@ -1,6 +1,6 @@
 module Skateparks
   class ShowSerializer < Skateparks::BaseSerializer
     attributes :id, :slug, :name, :city, :state, :map_photo, :stars, :obstacles, :hours, :material, :designer, :builder,
-               :opened, :size, :lights, :address, :info, :average_rating
+               :opened, :size, :lights, :address, :info, :average_rating, :status
   end
 end

--- a/db/migrate/20240407073617_add_status_to_skateparks.rb
+++ b/db/migrate/20240407073617_add_status_to_skateparks.rb
@@ -1,0 +1,5 @@
+class AddStatusToSkateparks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :skateparks, :status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_25_154642) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_07_073617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_25_154642) do
     t.string "zip_code"
     t.string "obstacles", array: true
     t.float "stars"
+    t.integer "status", default: 0, null: false
     t.index ["slug"], name: "index_skateparks_on_slug", unique: true
   end
 

--- a/spec/models/skatepark_spec.rb
+++ b/spec/models/skatepark_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Skatepark, type: :model do
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_inclusion_of(:state).in_array(Skatepark::STATES) }
+    it { is_expected.to define_enum_for(:status).with_values(open: 0, closed: 1) }
 
     it 'validates obstacles' do
       skatepark = build_stubbed(:skatepark, obstacles: ['fuck all'])

--- a/spec/serializers/skateparks/show_serializer_spec.rb
+++ b/spec/serializers/skateparks/show_serializer_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Skateparks::ShowSerializer do
+  it 'declares map attributes' do
+    attributes = %i[id slug name city state map_photo stars obstacles hours material designer builder
+                    opened size lights address info average_rating status]
+
+    expect(Skateparks::ShowSerializer.new(nil).attributes).to eq attributes
+  end
+end


### PR DESCRIPTION
Add `status` enum column to `skateparks`
- default to open
- non null (safe to add in Postgres 11+)
- adjust SEO title to reflect closed status
- don't display map for closed parks
- add display for closed status:

<img width="1043" alt="Screenshot 2024-04-07 at 9 04 01 AM" src="https://github.com/alookatommorow/west-coast-skateparks/assets/10751085/2fbb5767-e93e-4941-a94c-c91e157fc832">
