### PR TITLE
add support for slug history

### DIFF
--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -1,6 +1,7 @@
 class SkateparksController < ApplicationController
+  before_action :find_skatepark, only: :show
+
   def show
-    @skatepark = Skatepark.find(params[:slug])
     @skatepark_json = Skateparks::ShowSerializer.new(@skatepark).serialize
     @has_favorited = !!current_user&.favorited?(@skatepark.id)
     @has_visited = !!current_user&.visited?(@skatepark.id)
@@ -16,5 +17,18 @@ class SkateparksController < ApplicationController
     @skateparks = Skateparks::SearchSerializer.new(
       Skatepark.all.order(:state, :city, :name)
     ).serialize
+  end
+
+  private
+
+  def find_skatepark
+    @skatepark = Skatepark.find(params[:slug])
+
+    # If an old id or a numeric id was used to find the record, then
+    # the request path will not match the skatepark_path, and we should do
+    # a 301 redirect that uses the current friendly id.
+    return unless request.path != skatepark_path(@skatepark)
+
+    redirect_to @skatepark, status: :moved_permanently
   end
 end

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -94,7 +94,7 @@ class Skatepark < ActiveRecord::Base
 
   STARS = [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].freeze
 
-  friendly_id :to_param, use: %i[slugged finders]
+  friendly_id :to_param, use: %i[slugged history finders]
 
   validates :name, :city, presence: true
   validates :state, presence: true, inclusion: { in: STATES }
@@ -157,6 +157,10 @@ class Skatepark < ActiveRecord::Base
 
   def to_s
     (name.downcase.include?('skatepark') ? name : "#{name} skatepark").titleize
+  end
+
+  def should_generate_new_friendly_id?
+    will_save_change_to_name? || super
   end
 
   private

--- a/spec/models/skatepark_spec.rb
+++ b/spec/models/skatepark_spec.rb
@@ -13,9 +13,7 @@ RSpec.describe Skatepark, type: :model do
   describe 'validations' do
     subject { build_stubbed(:skatepark) }
     it { is_expected.to validate_numericality_of(:stars).is_in(1..5) }
-    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:city) }
-    it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_presence_of(:state) }
     it { is_expected.to validate_inclusion_of(:state).in_array(Skatepark::STATES) }
     it { is_expected.to define_enum_for(:status).with_values(open: 0, closed: 1) }
@@ -27,6 +25,15 @@ RSpec.describe Skatepark, type: :model do
       expect(skatepark.errors.messages[:whitelist_obstacles]).to eq(
         ['The obstacles are fucked']
       )
+    end
+
+    it 'updates slug' do
+      name = 'blarga124 clontark'
+      skatepark = create(:skatepark)
+
+      skatepark.update(name:)
+
+      expect(skatepark.slug).to include name.parameterize
     end
   end
 

--- a/spec/requests/skateparks/show_spec.rb
+++ b/spec/requests/skateparks/show_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe '/skateparks' do
       expect(assigns(:ratings)).to eq ratings
     end
 
+    context 'when slug has changed' do
+      it 'sets has_favorited and has_visited instance vars' do
+        skatepark = create(:skatepark)
+        old_slug = skatepark.slug
+
+        skatepark.update(name: 'new skatepark name')
+
+        get "/skateparks/#{old_slug}"
+
+        expect(response).to redirect_to skatepark_path(skatepark)
+      end
+    end
+
     context 'with ratings' do
       it 'sets ratings instance var' do
         skatepark = create(:skatepark)


### PR DESCRIPTION
Add support for finding records by slug after a name change. Existing slugs will be backfilled:
```ruby
FriendlyId::Slug.insert_all(
  Skatepark.all.map do |park|
    {
      slug: park.slug,
      sluggable_id: park.id,
      sluggable_type: 'Skatepark'
    }
  end
)
```