### PR TITLE
Fix/neighbor parks

### DIFF
--- a/app/javascript/pages/skateparks/show/index.tsx
+++ b/app/javascript/pages/skateparks/show/index.tsx
@@ -74,6 +74,11 @@ export const SkateparksShow = ({
 
   const handleFlashClose = () => setError('');
 
+  const showMap =
+    skatepark.status === 'open' &&
+    skatepark.latitude !== undefined &&
+    skatepark.longitude !== undefined;
+
   return (
     <div
       className={classNames('skatepark-show-container', {
@@ -144,7 +149,7 @@ export const SkateparksShow = ({
         {skatepark.photos && skatepark.photos.length > 1 && (
           <Photos photos={skatepark.photos} />
         )}
-        {skatepark.status === 'open' && (
+        {showMap && (
           <GMap
             resourceName="skatepark"
             resourceId={Number(skatepark.id)}

--- a/app/models/skatepark.rb
+++ b/app/models/skatepark.rb
@@ -89,6 +89,7 @@ class Skatepark < ActiveRecord::Base
     'oregon' => 'OR',
     'washington' => 'WA'
   }.freeze
+  NEIGHBOR_RADIUS = 0.4
 
   include Skateparks::Mappable
 
@@ -124,17 +125,18 @@ class Skatepark < ActiveRecord::Base
   scope :in_state, ->(state) { where(state:) }
 
   def neighbor_parks
-    radius = 0.4
+    return [] unless coordinates?
+
     self.class
         .where.not(id:)
         .where(
           'latitude BETWEEN ? AND ?',
-          latitude - radius,
-          latitude + radius
+          latitude - NEIGHBOR_RADIUS,
+          latitude + NEIGHBOR_RADIUS
         ).where(
           'longitude BETWEEN ? AND ?',
-          longitude - radius,
-          longitude + radius
+          longitude - NEIGHBOR_RADIUS,
+          longitude + NEIGHBOR_RADIUS
         )
   end
 

--- a/spec/models/skatepark_spec.rb
+++ b/spec/models/skatepark_spec.rb
@@ -59,10 +59,12 @@ RSpec.describe Skatepark, type: :model do
       expect(skatepark.average_rating).to eq(2.5)
     end
 
-    it 'returns nil if skatepark has not been rated' do
-      skatepark = create(:skatepark)
+    context 'with no ratings' do
+      it 'returns nil' do
+        skatepark = create(:skatepark)
 
-      expect(skatepark.average_rating).to be nil
+        expect(skatepark.average_rating).to be nil
+      end
     end
   end
 
@@ -83,6 +85,28 @@ RSpec.describe Skatepark, type: :model do
       json = skatepark.map_data
 
       expect(json).to eq expected
+    end
+  end
+
+  describe '#neighbor_parks' do
+    it 'returns skateparks with lat/lng within radius' do
+      range = 0..Skatepark::NEIGHBOR_RADIUS
+      outside_range = Skatepark::NEIGHBOR_RADIUS + 0.01
+      skatepark = create(:skatepark)
+      create(:skatepark, latitude: skatepark.latitude + outside_range,
+                         longitude: skatepark.longitude + Skatepark::NEIGHBOR_RADIUS)
+      neighbor_parks = create_list(:skatepark, 2, latitude: skatepark.latitude + rand(range),
+                                                  longitude: skatepark.longitude + rand(range))
+
+      expect(skatepark.neighbor_parks).to match_array neighbor_parks
+    end
+
+    context 'when lat or lng is nil' do
+      it 'returns empty array' do
+        skatepark = create(:skatepark, latitude: nil)
+
+        expect(skatepark.neighbor_parks).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
Add `nil` handling for `Skatepark#neighbor_parks`. Additionally, don't show map on show page when lat/lng are `nil`